### PR TITLE
display each sheet in its own line when listing sheets.

### DIFF
--- a/lib/sheet/list.rb
+++ b/lib/sheet/list.rb
@@ -3,7 +3,7 @@ class Sheet
   class List
 
     def list
-      Sheet.exec("ls #{Sheet.sheets_dir}", true)
+      Sheet.exec("ls -1 #{Sheet.sheets_dir}", true)
     end
   end
 end


### PR DESCRIPTION
using 'ls -1' instead of 'ls' so that each sheet is displayed in its own line, instead of putting all sheets in one line.
