### PR TITLE
"sheet new" to not throw an exception

### DIFF
--- a/lib/sheet.rb
+++ b/lib/sheet.rb
@@ -90,7 +90,7 @@ class Sheet
   # intended to do and then instantiate the proper class
   # TODO: refactor in a switch statement
   def process
-    if ['new', 'edit'].include?(@args[0])
+    if ['new', 'edit'].include?(@args[0]) && @args[1]
       write(@args[1])
     elsif ['ls', 'list'].include?(@args[0]) || @args.empty?
       list


### PR DESCRIPTION
Right now if you issue the command "sheet new" without a name parameter, ruby throws an exception. The patch makes sheet treat "sheet new" as if it were just looking for the sheet named "new". 
