### PR TITLE
Fixes: command_available can run 'type'.

### DIFF
--- a/lib/sheet.rb
+++ b/lib/sheet.rb
@@ -81,7 +81,7 @@ class Sheet
     # Utility to check wherever a command is available in the user
     # system
     def command_available?(cmd)
-      %x!type #{cmd}!.chomp.length > 0 rescue false
+      %x!bash -c "type #{cmd}" 2>/dev/null!.chomp.length > 0 rescue false
     end
 
     # Returns true if ~/.sheets exists


### PR DESCRIPTION
'type' is a Bash builtin in most Linux distros. %x expects a command (a
file) to run, so fails to run the builtin.

The fix runs 'type' inside a shell.
